### PR TITLE
feat(git): migrate diff pager to delta and fix worktree-aware branch cleanup

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -14,7 +14,7 @@ Use this to compare against your system and spot what's missing.
 | Package | Description |
 |---|---|
 | bat | cat clone with syntax highlighting |
-| diff-so-fancy | human-readable git diffs |
+| git-delta | syntax-highlighting git diff pager |
 | tmux | terminal multiplexer |
 
 **Casks** (`packages/Caskfile`):
@@ -64,7 +64,7 @@ Empty — no fonts installed yet. Needs Nerd Font for Powerlevel10k and tmux pow
 | btop | system monitor |
 | cmatrix | matrix rain screensaver |
 | ctop | container metrics |
-| diff-so-fancy | human-readable diffs |
+| git-delta | syntax-highlighting git diff pager |
 | docker | container runtime |
 | docker-compose | multi-container orchestration |
 | duf | disk usage utility |
@@ -178,7 +178,7 @@ Loaded in order: asdf, atuin, homebrew, cargo, nvm.
 | Tool | Usage |
 |---|---|
 | nvim | core editor |
-| diff-so-fancy | core pager (via `diff-so-fancy \| less`) |
+| git-delta | core pager — syntax-highlighted diffs |
 | ssh (ed25519) | GPG signing format |
 
 ### Git aliases (`config/git/.gitconfig [alias]`)

--- a/config/git/.gitconfig
+++ b/config/git/.gitconfig
@@ -9,7 +9,14 @@
 [core]
   editor = nvim
   excludesfile = ~/.gitignore_global
-  pager = diff-so-fancy | less --tabs=4 -RFX
+  pager = delta
+
+[interactive]
+  diffFilter = delta --color-only
+
+[delta]
+  navigate = true
+  line-numbers = true
 
 [gpg]
   format = ssh
@@ -67,7 +74,7 @@
   ftp = fetch --prune
 
   # helpers
-  bam = !git branch --merged | grep -v '\\*\\|master\\|develop\\|main' | xargs -n 1 git branch -d
+  bam = !git branch --merged | grep -vE '^[+*]|(master|develop|main)' | xargs -r -n 1 git branch -d
 
   # lists
   aliases = !git config --get-regexp 'alias.*' | colrm 1 6 | sed 's/[ ]/ = /' | sort

--- a/config/zsh/.functions
+++ b/config/zsh/.functions
@@ -17,7 +17,7 @@ function e {
 function git-clean {
   git fetch -p
 
-  for branch in `LC_ALL=C git branch -vv | grep ': gone]' | awk '{print $1}'`; do
+  for branch in `LC_ALL=C git branch -vv | grep ': gone]' | awk '$1 != "+" && $1 != "*" { print $1 }'`; do
     git branch -D $branch
   done
 }

--- a/packages/Brewfile
+++ b/packages/Brewfile
@@ -1,7 +1,7 @@
 atuin
 bat
 btop
-diff-so-fancy
+git-delta
 duf
 eza
 gemini-cli

--- a/packages/pacman.txt
+++ b/packages/pacman.txt
@@ -4,7 +4,7 @@ bat
 btop
 cmatrix
 ctop
-diff-so-fancy
+git-delta
 docker
 docker-compose
 duf


### PR DESCRIPTION
## What

Fixes three issues reported on Hades (TASK-040):

1. **`git df` / `git br` failing** — `diff-so-fancy` was set as `core.pager`, so it also filtered `git branch` output, which it can't parse. Migrated the pager to **git-delta** (passes non-diff through cleanly), and added `interactive.diffFilter` + a `[delta]` block (navigate, line-numbers).

2. **`git-clean` / `bam` trying to delete branch `'+'`** — git marks worktree-checked-out branches with a leading `+` (like `*` for current). Both helpers parsed `git branch` output without skipping that marker, so `+` reached `git branch -D`. Both now exclude `^[+*]`.

3. **Manifests + docs** — swapped `diff-so-fancy` → `git-delta` in `packages/Brewfile`, `packages/pacman.txt`, and `TOOLS.md`.

## Notes

- `git-delta` is in Arch `extra` (`pacman -S git-delta`) and Homebrew (`brew install git-delta`) — no AUR needed.
- After merge: `git -C ~/.dotfiles pull` makes it live (symlinks already point at the repo).
- Verified: gitconfig parses, `zsh -n` passes on `.functions`, awk fix tested (skips `+`/`*` markers).